### PR TITLE
feat: add city-specific search support to ScrapingRobot provider

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "serpbear",
-  "version": "2.0.7",
+  "version": "2.0.8",
   "private": true,
   "scripts": {
     "dev": "next dev",

--- a/scrapers/services/scrapingrobot.ts
+++ b/scrapers/services/scrapingrobot.ts
@@ -1,12 +1,21 @@
+import countries from '../../utils/countries';
+import { encodeUULE } from '../../utils/uule';
+
 const scrapingRobot:ScraperSettings = {
    id: 'scrapingrobot',
    name: 'Scraping Robot',
    website: 'scrapingrobot.com',
+   allowsCity: true,
    scrapeURL: (keyword, settings, countryData) => {
       const country = keyword.country || 'US';
       const device = keyword.device === 'mobile' ? '&mobile=true' : '';
       const lang = countryData[country][2];
-      const url = encodeURI(`https://www.google.com/search?num=100&hl=${lang}&q=${keyword.keyword}`);
+      const countryName = countries[country]?.[0];
+      const cityValue = keyword.city?.trim();
+      const uuleLocation = cityValue && countryName ? `${cityValue}, ${countryName}` : cityValue;
+      const uule = uuleLocation ? encodeUULE(uuleLocation) : '';
+      const locationParam = uule ? `&uule=${uule}` : '';
+      const url = encodeURI(`https://www.google.com/search?num=100&hl=${lang}&q=${keyword.keyword}${locationParam}`);
       return `https://api.scrapingrobot.com/?token=${settings.scaping_api}&proxyCountry=${country}&render=false${device}&url=${url}`;
    },
    resultObjectKey: 'result',

--- a/utils/uule.ts
+++ b/utils/uule.ts
@@ -1,0 +1,35 @@
+const UULE_PREFIX = 'w+CAIQICI';
+const BASE64_ALPHABET = 'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/';
+
+const encodeLength = (length:number): string => {
+   if (length <= 0) {
+      return 'A';
+   }
+
+   let encoded = '';
+   let value = length;
+
+   while (value > 0) {
+      const remainder = value % 64;
+      encoded = `${BASE64_ALPHABET[remainder]}${encoded}`;
+      value = Math.floor(value / 64);
+   }
+
+   return encoded;
+};
+
+export const encodeUULE = (city: string): string => {
+   const trimmedCity = city.trim();
+
+   if (!trimmedCity) {
+      return '';
+   }
+
+   const locationBuffer = Buffer.from(trimmedCity, 'utf8');
+   const lengthIndicator = encodeLength(locationBuffer.length);
+   const encodedLocation = locationBuffer.toString('base64');
+
+   return `${UULE_PREFIX}${lengthIndicator}${encodedLocation}`;
+};
+
+export default encodeUULE;


### PR DESCRIPTION
## Summary
- allow ScrapingRobot searches to specify a city and append a Google uule parameter when present
- add a reusable encodeUULE helper that produces Google-compatible base64 values
- bump the package version to 2.0.8 to reflect the new capability

## Testing
- npm run lint
- npm run test:ci *(fails: TextEncoder is not defined / useUpdateSettings mutate undefined in existing tests)*

------
https://chatgpt.com/codex/tasks/task_b_68cbc9262fec8329b4a5f5ddb30a3eb8