### PR TITLE
Fix keyword edit modal domain prop reference

### DIFF
--- a/__tests__/components/Keyword.test.tsx
+++ b/__tests__/components/Keyword.test.tsx
@@ -9,6 +9,7 @@ const keywordProps = {
    showSCData: false,
    scDataType: '',
    style: {},
+   maxTitleColumnWidth: 240,
    refreshkeyword: jest.fn(),
    favoriteKeyword: jest.fn(),
    removeKeyword: jest.fn(),

--- a/components/keywords/KeywordsTable.tsx
+++ b/components/keywords/KeywordsTable.tsx
@@ -28,7 +28,7 @@ type KeywordsTableProps = {
 
 const KeywordsTable = (props: KeywordsTableProps) => {
    const titleColumnRef = useRef(null);
-   const { keywords = [], isLoading = true, isConsoleIntegrated = false, settings } = props;
+   const { domain: currentDomain, keywords = [], isLoading = true, isConsoleIntegrated = false, settings } = props;
    const showSCData = isConsoleIntegrated;
    const [device, setDevice] = useState<string>('desktop');
    const [selectedKeywords, setSelectedKeywords] = useState<number[]>([]);
@@ -310,7 +310,7 @@ const KeywordsTable = (props: KeywordsTableProps) => {
             <EditKeyword
                keyword={keywordToEdit}
                closeModal={() => setKeywordToEdit(null)}
-               domain={domain?.domain || ''}
+               domain={currentDomain?.domain ?? ''}
                availableTags={allDomainTags}
                allowsCity={!!activeScraper?.allowsCity}
                scraperName={activeScraper?.label || ''}

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "serpbear",
-  "version": "2.0.10",
+  "version": "2.0.11",
   "private": true,
   "scripts": {
     "dev": "next dev",


### PR DESCRIPTION
## Summary
- derive the current domain from props in `KeywordsTable` and pass it to the edit keyword modal
- update the keyword component tests with the required `maxTitleColumnWidth` prop
- bump the application version to 2.0.11

## Testing
- npm run lint
- npx tsc --noEmit
- npm run test:ci

------
https://chatgpt.com/codex/tasks/task_b_68cbe212de648329930114c40cfb8160